### PR TITLE
feat: add sentence practice to notebook

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -607,7 +607,7 @@ const App: React.FC = () => {
     const renderScreen = () => {
         switch (appScreen) {
             case AppScreen.NOTEBOOK:
-                return <NotebookView notebook={notebook} onUpdateNotebook={handleUpdateNotebook} onClose={() => setAppScreen(AppScreen.GAME)} onDelete={handleDeleteFromNotebook} />;
+                return <NotebookView notebook={notebook} targetLanguage={userSettings?.targetLanguage || ''} onUpdateNotebook={handleUpdateNotebook} onClose={() => setAppScreen(AppScreen.GAME)} onDelete={handleDeleteFromNotebook} />;
             case AppScreen.GAME:
                 if (!gameState || !userSettings) {
                     return (


### PR DESCRIPTION
## Summary
- add grammar-checking sentence practice modal for vocabulary notebook
- integrate Gemini-based grammar checker service
- pass target language to notebook view

## Testing
- `npm test` (fails: Missing script "test")
- `API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb1a43d448323ae849fa6d3e54e5a