### PR TITLE
feat: add writing practice and filter to notebook

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -508,6 +508,7 @@ const App: React.FC = () => {
         const newItem: SavedVocabularyItem = {
             ...item, id: crypto.randomUUID(), dateAdded: new Date().toISOString(),
             correctCount: 0, incorrectCount: 0,
+            sourceLanguage: userSettings.sourceLanguage,
         };
         try {
             await db.notebook.add(newItem);
@@ -563,6 +564,7 @@ const App: React.FC = () => {
         const newItems: SavedVocabularyItem[] = wordsToSave.map(item => ({
             ...item, id: crypto.randomUUID(), dateAdded: new Date().toISOString(),
             correctCount: 0, incorrectCount: 0,
+            sourceLanguage: userSettings?.sourceLanguage || '',
         }));
         try {
             await db.notebook.bulkAdd(newItems);
@@ -607,7 +609,7 @@ const App: React.FC = () => {
     const renderScreen = () => {
         switch (appScreen) {
             case AppScreen.NOTEBOOK:
-                return <NotebookView notebook={notebook} onUpdateNotebook={handleUpdateNotebook} onClose={() => setAppScreen(AppScreen.GAME)} onDelete={handleDeleteFromNotebook} />;
+                return <NotebookView notebook={notebook} targetLanguage={userSettings?.targetLanguage || ''} sourceLanguage={userSettings?.sourceLanguage || ''} onUpdateNotebook={handleUpdateNotebook} onClose={() => setAppScreen(AppScreen.GAME)} onDelete={handleDeleteFromNotebook} />;
             case AppScreen.GAME:
                 if (!gameState || !userSettings) {
                     return (

--- a/types.ts
+++ b/types.ts
@@ -36,6 +36,7 @@ export interface SavedVocabularyItem extends VocabularyItem {
     dateAdded: string;
     correctCount: number;
     incorrectCount: number;
+    sourceLanguage: string;
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- track source language on saved vocabulary
- add writing practice workflow with grammar correction and sample sentences
- enable keyboard navigation and filtering with select-all for flashcards and writing

## Testing
- `npm test` (fails: Missing script "test")
- `API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb1a43d448323ae849fa6d3e54e5a