### PR TITLE
Add Gemini API key management and auto-rotation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -151,9 +151,7 @@ const App: React.FC = () => {
     const [speakingState, setSpeakingState] = useState<{ type: 'story' | 'word'; key: string } | null>(null);
     const [toasts, setToasts] = useState<ToastMessage[]>([]);
 
-    useEffect(() => {
-        apiKeyService.init();
-    }, []);
+    // API key initialization now happens at startup (index.tsx)
 
 
     const gameState = history[currentStepIndex] ?? null;
@@ -238,7 +236,8 @@ const App: React.FC = () => {
     useEffect(() => {
         apiKeyService.onChange((key, changeType) => {
             if (changeType === 'auto') {
-                addToast(`API key exhausted. Switched to ${key.slice(0,6)}...`, 'success');
+                const masked = `${key.slice(0,6)}...${key.slice(-4)}`;
+                addToast(`API key exhausted. Switched to ${masked}`, 'success');
             }
         });
     }, [addToast]);

--- a/App.tsx
+++ b/App.tsx
@@ -146,6 +146,7 @@ const App: React.FC = () => {
     const [isImageFullscreen, setIsImageFullscreen] = useState(false);
     const [currentImageUrl, setCurrentImageUrl] = useState<string>('');
     const [showStorageWarning, setShowStorageWarning] = useState(false);
+    const [hasWarnedStorage, setHasWarnedStorage] = useState(false);
     const [selectedInteractiveWords, setSelectedInteractiveWords] = useState<VocabularyItem[]>([]);
     const [translatingWord, setTranslatingWord] = useState<string | null>(null);
     const [speakingState, setSpeakingState] = useState<{ type: 'story' | 'word'; key: string } | null>(null);
@@ -257,7 +258,14 @@ const App: React.FC = () => {
                 const sizeMB = (totalBytes / (1024 * 1024)).toFixed(1);
                 setSaveDataInfo({ size: sizeMB, steps: history.length });
                 
-                setShowStorageWarning(totalBytes > STORAGE_WARNING_THRESHOLD_BYTES);
+                const overThreshold = totalBytes > STORAGE_WARNING_THRESHOLD_BYTES;
+                setShowStorageWarning(overThreshold);
+                if (overThreshold && !hasWarnedStorage) {
+                    setHasWarnedStorage(true);
+                    addToast(`Storage is high (~${sizeMB} MB). Please Save your game to a file to avoid data loss.`, 'error', 8000);
+                } else if (!overThreshold && hasWarnedStorage) {
+                    setHasWarnedStorage(false);
+                }
 
             } catch (e) {
                 console.error("Error calculating save size:", e);
@@ -266,8 +274,9 @@ const App: React.FC = () => {
         } else {
             setSaveDataInfo(null);
             setShowStorageWarning(false);
+            setHasWarnedStorage(false);
         }
-    }, [history, userSettings, currentStepIndex, characterProfiles, addToast]);
+    }, [history, userSettings, currentStepIndex, characterProfiles, addToast, hasWarnedStorage]);
 
     useEffect(() => {
         updateSaveDataInfo();
@@ -292,8 +301,7 @@ const App: React.FC = () => {
             let imageId: string | undefined = undefined;
             if (settings.generateImages) {
                 setLoadingState(LoadingState.GENERATING_IMAGE);
-                imageUrl = await generateAdventureImage(initialStep.imagePrompt);
-                const blob = base64ToBlob(imageUrl, 'image/jpeg');
+                const blob = await generateAdventureImage(initialStep.imagePrompt);
                 imageId = crypto.randomUUID();
                 await db.images.put({ id: imageId, blob });
             }
@@ -339,12 +347,11 @@ const App: React.FC = () => {
             let imageId: string | undefined = undefined;
             if (userSettings?.generateImages) {
                 setLoadingState(LoadingState.GENERATING_IMAGE);
-                imageUrl = await generateAdventureImage(nextStep.imagePrompt);
-                const blob = base64ToBlob(imageUrl, 'image/jpeg');
+                const blob = await generateAdventureImage(nextStep.imagePrompt);
                 imageId = crypto.randomUUID();
                 await db.images.put({ id: imageId, blob });
             }
-            
+
             const newGameState: GameState = { ...nextStep, imageUrl, imageId };
 
             const newCharacterProfiles = [...characterProfiles];
@@ -654,6 +661,14 @@ const App: React.FC = () => {
                             <header className="flex justify-between items-center mb-4 border-b border-gray-700 pb-4 flex-wrap gap-y-2">
                                 <h1 className="text-2xl font-bold text-purple-300">{userSettings.genre}</h1>
                                 <div className="flex gap-2 items-center flex-wrap">
+                                    {saveDataInfo && (
+                                        <div
+                                            className={`text-xs px-2 py-1 rounded border ${showStorageWarning ? 'bg-yellow-900/50 text-yellow-300 border-yellow-700/80' : 'bg-gray-800/60 text-gray-300 border-gray-700/80'}`}
+                                            title={`Approximate local storage used${showStorageWarning ? ' (over recommended limit)' : ''}`}
+                                        >
+                                            Storage: {saveDataInfo.size} MB
+                                        </div>
+                                    )}
                                     <div className="flex items-center gap-2 text-sm mr-4">
                                         <input
                                             type="checkbox"
@@ -775,8 +790,9 @@ const App: React.FC = () => {
                                 </div>
                             )}
                             {showStorageWarning && (
-                                <div className="mt-4 p-4 bg-yellow-900/50 border border-yellow-700/80 rounded-lg text-yellow-300 text-sm">
-                                    <strong>Storage Warning:</strong> Using {saveDataInfo?.size} MB. Consider saving and starting a new game soon.
+                                <div className="mt-4 p-4 bg-yellow-900/50 border border-yellow-700/80 rounded-lg text-yellow-300 text-sm flex items-center justify-between gap-3">
+                                    <span><strong>Storage Warning:</strong> Using {saveDataInfo?.size} MB. Please save your game to a file.</span>
+                                    <button onClick={handleManualSave} className="bg-yellow-700 hover:bg-yellow-600 text-yellow-50 font-semibold py-1 px-3 rounded-md">Save Now</button>
                                 </div>
                             )}
                         </main>

--- a/components/ApiKeyManager.tsx
+++ b/components/ApiKeyManager.tsx
@@ -6,7 +6,11 @@ interface Props {
   onToast: (msg: string, type?: 'error' | 'success') => void;
 }
 
-const maskKey = (key: string) => `${key.slice(0,6)}...`;
+const maskKey = (key: string) => {
+  const head = key.slice(0, 6);
+  const tail = key.slice(-4);
+  return `${head}...${tail}`;
+};
 
 const ApiKeyManager: React.FC<Props> = ({ onBack, onToast }) => {
   const [keys, setKeys] = useState<string[]>([]);

--- a/components/ApiKeyManager.tsx
+++ b/components/ApiKeyManager.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import apiKeyService from '../services/apiKeyService';
+
+interface Props {
+  onBack: () => void;
+  onToast: (msg: string, type?: 'error' | 'success') => void;
+}
+
+const maskKey = (key: string) => `${key.slice(0,6)}...`;
+
+const ApiKeyManager: React.FC<Props> = ({ onBack, onToast }) => {
+  const [keys, setKeys] = useState<string[]>([]);
+  const [newKey, setNewKey] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const refresh = () => {
+    const all = apiKeyService.getKeys();
+    setKeys(all);
+    const activeKey = apiKeyService.getActiveKey();
+    const idx = all.findIndex(k => k === activeKey);
+    setActiveIndex(idx === -1 ? 0 : idx);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleAdd = () => {
+    const trimmed = newKey.trim();
+    if (!trimmed) {
+      onToast('Please enter an API key.', 'error');
+      return;
+    }
+    apiKeyService.addKey(trimmed);
+    setNewKey('');
+    refresh();
+    onToast('API key added.', 'success');
+  };
+
+  const handleUse = (index: number) => {
+    apiKeyService.setActiveKey(index);
+    refresh();
+    const key = apiKeyService.getActiveKey();
+    if (key) {
+      onToast(`Switched to API key ${maskKey(key)}`, 'success');
+    }
+  };
+
+  const handleRemove = (index: number) => {
+    apiKeyService.removeKey(index);
+    refresh();
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-200 p-4">
+      <div className="max-w-xl mx-auto">
+        <h2 className="text-2xl font-bold mb-6 text-center text-purple-300">API Key Management</h2>
+        {keys.length === 0 ? (
+          <p className="mb-4">No API keys available.</p>
+        ) : (
+          <ul className="space-y-2 mb-6">
+            {keys.map((key, idx) => (
+              <li key={idx} className="flex items-center justify-between bg-gray-800 p-3 rounded">
+                <span>{maskKey(key)}{idx === activeIndex && ' (active)'}</span>
+                <div className="space-x-2">
+                  {idx !== activeIndex && (
+                    <button onClick={() => handleUse(idx)} className="bg-purple-600 hover:bg-purple-700 text-white px-2 py-1 rounded text-sm">Use</button>
+                  )}
+                  <button onClick={() => handleRemove(idx)} className="bg-red-600 hover:bg-red-700 text-white px-2 py-1 rounded text-sm">Remove</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="flex gap-2 mb-6">
+          <input
+            type="text"
+            value={newKey}
+            onChange={e => setNewKey(e.target.value)}
+            placeholder="Enter new API key"
+            className="flex-grow bg-gray-800 border border-gray-600 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+          <button onClick={handleAdd} className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">Add</button>
+        </div>
+        <div className="text-center">
+          <button onClick={onBack} className="underline">Back</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApiKeyManager;
+

--- a/components/GameSetup.tsx
+++ b/components/GameSetup.tsx
@@ -76,6 +76,15 @@ Key Characters/Factions:
 
 Key Events:
 - ${result.keyEvents.join('\n- ')}
+
+--- Player Character ---
+Role: ${result.playerRole}
+Background: ${result.playerBackground}
+Appearance: ${result.playerAppearance}
+Personality: ${result.playerPersonality}
+Skills: ${result.playerSkills.join(', ')}
+Equipment: ${result.playerEquipment.join(', ')}
+Starting Situation: ${result.startingSituation}
 --- End Context ---
 
 Adventure Start:

--- a/components/GameSetup.tsx
+++ b/components/GameSetup.tsx
@@ -11,17 +11,19 @@ interface GameSetupProps {
     error: string | null;
     onClearData?: () => void;
     onToast: (message: string, type?: 'error' | 'success') => void;
+    onManageApiKeys: () => void;
 }
 
 const GameSetup: React.FC<GameSetupProps> = ({ 
     onStartGame, 
     isLoading, 
     onLoadGame, 
-    onContinueGame, 
-    hasSaveData, 
+    onContinueGame,
+    hasSaveData,
     error,
     onClearData,
     onToast,
+    onManageApiKeys,
 }) => {
     const [prompt, setPrompt] = useState('');
     const [genre, setGenre] = useState('Dark Fantasy');
@@ -315,6 +317,14 @@ ${result.prompt}`;
                                 className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded-lg transition-colors w-full sm:w-auto disabled:opacity-50"
                             >
                                 Load from File
+                            </button>
+                            <button
+                                type="button"
+                                onClick={onManageApiKeys}
+                                disabled={isLoading}
+                                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg transition-colors w-full sm:w-auto disabled:opacity-50"
+                            >
+                                Manage API Keys
                             </button>
                              <input type="file" id="loadGameInput" className="hidden" accept=".json" onChange={handleFileChange} />
                         </div>

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import apiKeyService from './services/apiKeyService';
+
+// Initialize API keys before rendering the app to avoid race conditions
+apiKeyService.init();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/services/apiKeyService.ts
+++ b/services/apiKeyService.ts
@@ -1,0 +1,108 @@
+type Listener = (key: string, type: 'manual' | 'auto') => void;
+
+const STORAGE_KEYS = 'apiKeys';
+const STORAGE_ACTIVE_INDEX = 'activeApiKeyIndex';
+
+const getStoredKeys = (): string[] => {
+  const raw = localStorage.getItem(STORAGE_KEYS);
+  return raw ? JSON.parse(raw) : [];
+};
+
+const setStoredKeys = (keys: string[]) => {
+  localStorage.setItem(STORAGE_KEYS, JSON.stringify(keys));
+};
+
+const getActiveIndex = (): number => {
+  const idx = parseInt(localStorage.getItem(STORAGE_ACTIVE_INDEX) || '0', 10);
+  return isNaN(idx) ? 0 : idx;
+};
+
+const setActiveIndex = (index: number) => {
+  localStorage.setItem(STORAGE_ACTIVE_INDEX, index.toString());
+};
+
+let listeners: Listener[] = [];
+
+const notify = (key: string, type: 'manual' | 'auto') => {
+  listeners.forEach(cb => cb(key, type));
+};
+
+const init = () => {
+  const envKey = process.env.API_KEY;
+  const keys = getStoredKeys();
+  let changed = false;
+  if (envKey && !keys.includes(envKey)) {
+    keys.push(envKey);
+    changed = true;
+  }
+  if (changed) {
+    setStoredKeys(keys);
+  }
+  if (localStorage.getItem(STORAGE_ACTIVE_INDEX) === null && keys.length > 0) {
+    setActiveIndex(0);
+  }
+  if (getActiveIndex() >= keys.length && keys.length > 0) {
+    setActiveIndex(0);
+  }
+};
+
+const getActiveKey = (): string | null => {
+  const keys = getStoredKeys();
+  const idx = getActiveIndex();
+  return keys[idx] || null;
+};
+
+const addKey = (key: string) => {
+  const keys = getStoredKeys();
+  keys.push(key);
+  setStoredKeys(keys);
+  setActiveKey(keys.length - 1);
+};
+
+const setActiveKey = (index: number, type: 'manual' | 'auto' = 'manual') => {
+  const keys = getStoredKeys();
+  if (index < 0 || index >= keys.length) return;
+  setActiveIndex(index);
+  notify(keys[index], type);
+};
+
+const removeKey = (index: number) => {
+  const keys = getStoredKeys();
+  if (index < 0 || index >= keys.length) return;
+  keys.splice(index, 1);
+  setStoredKeys(keys);
+  let activeIdx = getActiveIndex();
+  if (index === activeIdx) {
+    activeIdx = 0;
+    setActiveIndex(activeIdx);
+    if (keys[activeIdx]) notify(keys[activeIdx], 'manual');
+  } else if (index < activeIdx) {
+    activeIdx -= 1;
+    setActiveIndex(activeIdx);
+  }
+};
+
+const switchToNextKey = (): boolean => {
+  const keys = getStoredKeys();
+  if (keys.length <= 1) return false;
+  const current = getActiveIndex();
+  const next = (current + 1) % keys.length;
+  if (next === current) return false;
+  setActiveKey(next, 'auto');
+  return true;
+};
+
+const onChange = (cb: Listener) => {
+  listeners.push(cb);
+};
+
+export default {
+  init,
+  getKeys: getStoredKeys,
+  getActiveKey,
+  addKey,
+  setActiveKey,
+  removeKey,
+  switchToNextKey,
+  onChange,
+};

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -355,7 +355,7 @@ Do not repeat the examples given. Each idea must be a short, punchy phrase suita
 }
 
 
-export const generateAdventureImage = async (prompt: string): Promise<string> => {
+export const generateAdventureImage = async (prompt: string): Promise<Blob> => {
     try {
         const response = await callGemini(client => client.models.generateImages({
             model: imageModel,
@@ -369,7 +369,13 @@ export const generateAdventureImage = async (prompt: string): Promise<string> =>
 
         if (response.generatedImages && response.generatedImages.length > 0) {
             const base64ImageBytes: string = response.generatedImages[0].image.imageBytes;
-            return `data:image/jpeg;base64,${base64ImageBytes}`;
+            const byteCharacters = atob(base64ImageBytes);
+            const byteNumbers = new Array(byteCharacters.length);
+            for (let i = 0; i < byteCharacters.length; i++) {
+                byteNumbers[i] = byteCharacters.charCodeAt(i);
+            }
+            const byteArray = new Uint8Array(byteNumbers);
+            return new Blob([byteArray], { type: 'image/jpeg' });
         }
         throw new Error("Image generation returned no images.");
     } catch (error) {

--- a/types.ts
+++ b/types.ts
@@ -10,6 +10,7 @@ export enum AppScreen {
   SETUP,
   GAME,
   NOTEBOOK,
+  API_KEY_MANAGER,
 }
 
 export interface UserSettings {

--- a/types.ts
+++ b/types.ts
@@ -76,6 +76,15 @@ export interface PromptSuggestion {
     worldDescription: string;
     keyCharacters: string[];
     keyEvents: string[];
+    // Extended player-focused details for richer setup
+    playerBackground: string;
+    playerRole: string;
+    playerSkills: string[];
+    startingSituation: string;
+    // Further extensions
+    playerAppearance: string;
+    playerPersonality: string;
+    playerEquipment: string[];
 }
 
 export interface ImageRecord {


### PR DESCRIPTION
## Summary
- add API key manager screen and button in main menu
- store multiple Gemini API keys and mask their display
- auto-rotate to next API key on quota exhaustion and show toast
- add save data info size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af340f24388323a8ae2a3f083d59d1