### PR TITLE
Configure preview server port for Render deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview"
   },
   "dependencies": {
     "@google/genai": "^1.15.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const port = parseInt(process.env.PORT || '');
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
@@ -12,6 +13,14 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      server: {
+        host: true,
+        port: port || 5173,
+      },
+      preview: {
+        host: true,
+        port: port || 4173,
       }
     };
 });


### PR DESCRIPTION
## Summary
- expose start script for Vite preview
- bind dev/preview servers to `PORT` and `0.0.0.0`

## Testing
- `npm run build`
- `PORT=1234 timeout 5 npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68afe5618fc8832387c851766ed03d7f